### PR TITLE
[FIX] Add missing define condition

### DIFF
--- a/arch/arm/src/stm32h7/hardware/stm32h7x3xx_spi.h
+++ b/arch/arm/src/stm32h7/hardware/stm32h7x3xx_spi.h
@@ -27,7 +27,7 @@
 
 #include <nuttx/config.h>
 
-#if defined(CONFIG_STM32H7_STM32H7X3XX)
+#if defined(CONFIG_STM32H7_STM32H7X3XX) || defined(CONFIG_STM32H7_STM32H7X7XX)
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
Without this the macros for SPI are not available on STM32H747.

Presumably this got lost in a merge or conflict.